### PR TITLE
Update README phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Sparky Beep
-Provides beep support for a few services of sbserver edition.
+Provides beep support for a few services of server edition.
 
 Copyright (C) 2018-2020 Paweł Pijanowski & Daniel Campos Ramos
 


### PR DESCRIPTION
## Summary
- reword README to reference the "server edition" instead of "sbserver edition"

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f41db5d588324b9afbf898da886f5