### PR TITLE
Add bats tests and fix service scripts

### DIFF
--- a/bin/sparky-beep-run
+++ b/bin/sparky-beep-run
@@ -8,15 +8,15 @@
 PACKNETDATA=`apt-cache policy netdata | head -n2 | tail -n1 | grep [0-9]`
 
 if [ "$PACKNETDATA" != "" ]; then
-	CHECKBEEPNETDATA=`systemctl status beep_netdata | grep inacitve`
+        CHECKBEEPNETDATA=`systemctl status beep_netdata | grep inactive`
 
-	if [ "$CHECKBEEPNETDATA" != " " ]; then
-		systemctl start beep_netdata
-		CHECKBEEPNETDATA0=`systemctl status beep_netdata | grep "Active: active"`
-		if [ "$CHECKBEEPNETDATA0" != " " ]; then
-			echo "beep_netdata service is active..."
-		else
-			echo "beep_netdata service is NOT active..."
+        if [ -n "$CHECKBEEPNETDATA" ]; then
+                systemctl start beep_netdata
+                CHECKBEEPNETDATA0=`systemctl status beep_netdata | grep "Active: active"`
+                if [ -n "$CHECKBEEPNETDATA0" ]; then
+                        echo "beep_netdata service is active..."
+                else
+                        echo "beep_netdata service is NOT active..."
 		fi
 	fi
 
@@ -31,10 +31,10 @@ fi
 PACKSAMBA=`apt-cache policy samba | head -n2 | tail -n1 | grep [0-9]`
 
 if [ "$PACKSAMBA" != "" ]; then
-	CHECKBEEPSAMBA=`systemctl status beep_samba | grep inacitve`
+        CHECKBEEPSAMBA=`systemctl status beep_samba | grep inactive`
 	CHECKSMBD=`systemctl status smbd | grep masked`
 	CHECKSAMBAADDC=`systemctl status samba-ad-dc | grep masked`
-	if [ "$CHECKBEEPSAMBA" != " " ]; then
+        if [ -n "$CHECKBEEPSAMBA" ]; then
 		if [ "$CHECKSMBD" = " " ]; then
 			systemctl stop smbd
 			systemctl disable smbd
@@ -46,12 +46,12 @@ if [ "$PACKSAMBA" != "" ]; then
 			systemctl start samba-ad-dc
 		fi
 		systemctl start beep_samba
-		CHECKBEEPSAMBA0=`systemctl status beep_samba | grep "Active: active"`
-		if [ "$CHECKBEEPSAMBA0" != " " ]; then
-			echo "beep_samba service is active..."
-		else
-			echo "beep_samba service is NOT active..."
-		fi
+                CHECKBEEPSAMBA0=`systemctl status beep_samba | grep "Active: active"`
+                if [ -n "$CHECKBEEPSAMBA0" ]; then
+                        echo "beep_samba service is active..."
+                else
+                        echo "beep_samba service is NOT active..."
+                fi
 	fi
 
 	# enable it if not enabled
@@ -62,14 +62,14 @@ if [ "$PACKSAMBA" != "" ]; then
 fi
 #####################################################################
 # check 3: beep_sys
-CHECKBEEPSYS=`systemctl status beep_sys | grep inacitve`
-if [ "$CHECKBEEPSYS" != " " ]; then
-	systemctl start beep_sys
-	CHECKBEEPSYS0=`systemctl status beep_sys | grep "Active: active"`
-	if [ "$CHECKBEEPSYS0" != " " ]; then
-		echo "beep_sys service is active..."
-	else
-		echo "beep_sys service is NOT active..."
+CHECKBEEPSYS=`systemctl status beep_sys | grep inactive`
+if [ -n "$CHECKBEEPSYS" ]; then
+        systemctl start beep_sys
+        CHECKBEEPSYS0=`systemctl status beep_sys | grep "Active: active"`
+        if [ -n "$CHECKBEEPSYS0" ]; then
+                echo "beep_sys service is active..."
+        else
+                echo "beep_sys service is NOT active..."
 	fi
 fi
 
@@ -83,14 +83,14 @@ fi
 PACKWEBMIN=`apt-cache policy webmin | head -n2 | tail -n1 | grep [0-9]`
 
 if [ "$PACKWEBMIN" != "" ]; then
-	CHECKBEEPWEBMIN=`systemctl status beep_webmin | grep inacitve`
-	if [ "$CHECKBEEPWEBMIN" != " " ]; then
-		systemctl start beep_webmin
-		CHECKBEEPWEBMIN0=`systemctl status beep_webmin | grep "Active: active"`
-		if [ "$CHECKBEEPWEBMIN0" != " " ]; then
-			echo "beep_webmin service is active..."
-		else
-			echo "beep_webmin service is NOT active..."
+        CHECKBEEPWEBMIN=`systemctl status beep_webmin | grep inactive`
+        if [ -n "$CHECKBEEPWEBMIN" ]; then
+                systemctl start beep_webmin
+                CHECKBEEPWEBMIN0=`systemctl status beep_webmin | grep "Active: active"`
+                if [ -n "$CHECKBEEPWEBMIN0" ]; then
+                        echo "beep_webmin service is active..."
+                else
+                        echo "beep_webmin service is NOT active..."
 		fi
 	fi
 

--- a/init.d/beep_webmin
+++ b/init.d/beep_webmin
@@ -25,7 +25,7 @@ for z in {3500..21..40}; do beep -f $z -d 20 -l 20; done;
 beep -f 660 -l 100 -d 150; beep -f 660 -l 100 -d 300;beep -f 660 -l 100 -d 300; beep -f 510 -l 100 -d 100; beep -f 660 -l 100 -d 300; beep -f 770 -l 100 -d 550;beep -f 380 -l 100 -d 575;
 ;;
   *)
-  echo "Use: /etc/init.d/beep_netdata {start|stop|restart}"
+  echo "Use: /etc/init.d/beep_webmin {start|stop|restart}"
   exit 1
   ;;
 esac

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+# Tests
+
+This project uses [Bats](https://github.com/bats-core/bats-core) for shell tests.
+
+## Running
+
+Install `bats` (e.g. `sudo apt-get install bats`).
+
+From the repository root run:
+
+```bash
+bats tests
+```
+

--- a/tests/init-usage.bats
+++ b/tests/init-usage.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+@test "usage text matches script name" {
+  for script in init.d/beep_*; do
+    service=$(basename "$script")
+    usage=$(grep -oE '/etc/init.d/[a-zA-Z0-9_-]+' "$script" | head -n1)
+    [ "$usage" = "/etc/init.d/$service" ]
+  done
+}
+
+

--- a/tests/sparky-beep-run.bats
+++ b/tests/sparky-beep-run.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+setup() {
+  TMPDIR=$(mktemp -d)
+  PATH="$TMPDIR:$PATH"
+  export TMP_STATE="$TMPDIR"
+
+  cat <<'EOS' > "$TMPDIR/systemctl"
+#!/bin/sh
+state="$TMP_STATE/beep_sys_started"
+cmd=$1
+unit=$2
+case "$cmd" in
+  status)
+    if [ -f "$state" ]; then
+      echo "Active: active (running)"
+      echo "Loaded: loaded (/etc/systemd/system/$unit.service; enabled)"
+    else
+      echo "Active: inactive (dead)"
+      echo "Loaded: loaded (/etc/systemd/system/$unit.service; disabled)"
+    fi
+    ;;
+  start)
+    touch "$state"
+    ;;
+  enable)
+    :
+    ;;
+  *)
+    :
+    ;;
+esac
+EOS
+  chmod +x "$TMPDIR/systemctl"
+
+  cat <<'EOS' > "$TMPDIR/apt-cache"
+#!/bin/sh
+exit 0
+EOS
+  chmod +x "$TMPDIR/apt-cache"
+
+  cat <<'EOS' > "$TMPDIR/beep"
+#!/bin/sh
+exit 0
+EOS
+  chmod +x "$TMPDIR/beep"
+}
+
+teardown() {
+  rm -rf "$TMPDIR"
+}
+
+@test "starts inactive beep_sys service" {
+  run bin/sparky-beep-run
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "beep_sys service is active"
+}
+


### PR DESCRIPTION
## Summary
- fix usage text for beep_webmin
- correct inactive service checks in sparky-beep-run
- add Bats tests for service script and init script usage
- document test execution instructions

## Testing
- `bats tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f41e5e7cc8324bb371caacba9e6a8